### PR TITLE
Remove eager toString() in Firehose#notify()

### DIFF
--- a/reactor-pipe/src/main/java/reactor/pipe/Firehose.java
+++ b/reactor-pipe/src/main/java/reactor/pipe/Firehose.java
@@ -120,7 +120,7 @@ public class Firehose<K> {
 
   public <V> Firehose notify(final K key, final V ev) {
     Assert.notNull(key, "Key cannot be null.");
-    Assert.notNull(ev, "Event cannot be null for key " + key.toString());
+    Assert.notNull(ev, "Event cannot be null.");
 
     // Backpressure
     while ((inDispatcherContext.get() == null || !inDispatcherContext.get()) &&


### PR DESCRIPTION
The current code will cause a toString() of the key whenever it is notified. While this is intended to help figuring out whats wrong, this is really expensive and garbage intensive (it strings the key and then string builders the message and the key)
